### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,14 +120,14 @@ The above example demonstrates ``external`` patching, but ``internal``
    :target: https://coveralls.io/r/themattrix/python-simian
 .. |Health| image:: https://landscape.io/github/themattrix/python-simian/master/landscape.svg
    :target: https://landscape.io/github/themattrix/python-simian/master
-.. |Version| image:: https://pypip.in/version/simian/badge.svg?text=version
+.. |Version| image:: https://img.shields.io/pypi/v/simian.svg?label=version
     :target: https://pypi.python.org/pypi/simian
-.. |Downloads| image:: https://pypip.in/download/simian/badge.svg
+.. |Downloads| image:: https://img.shields.io/pypi/dm/simian.svg
     :target: https://pypi.python.org/pypi/simian
-.. |Compatibility| image:: https://pypip.in/py_versions/simian/badge.svg
+.. |Compatibility| image:: https://img.shields.io/pypi/pyversions/simian.svg
     :target: https://pypi.python.org/pypi/simian
-.. |Implementations| image:: https://pypip.in/implementation/simian/badge.svg
+.. |Implementations| image:: https://img.shields.io/pypi/implementation/simian.svg
     :target: https://pypi.python.org/pypi/simian
-.. |Format| image:: https://pypip.in/format/simian/badge.svg
+.. |Format| image:: https://img.shields.io/pypi/format/simian.svg
     :target: https://pypi.python.org/pypi/simian
 .. _mock.patch: https://docs.python.org/3/library/unittest.mock.html#patch


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20simian))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `simian`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.